### PR TITLE
Removed apostrophes causing an error in npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "prestart": "npm run -s build",
     "start": "node dist/index.js",
-    "dev": "nodemon src/index.js --exec \"node -r 'dotenv/config' -r 'babel-register'\"",
+    "dev": "nodemon src/index.js --exec \"node -r dotenv/config -r babel-register\"",
     "clean": "rm -rf dist",
     "build": "npm run clean && mkdir -p dist && babel src -s -D -d dist --presets es2015,stage-2",
     "test": "jest --watch",


### PR DESCRIPTION
Running 'npm run dev' was crashing the app with the following error: 
```
$ npm run dev

> gamelobby@1.0.0 dev W:\sites\gamelobby
> nodemon src/index.js --exec "node -r 'dotenv/config' -r 'babel-register'"

[nodemon] 1.11.0
[nodemon] to restart at any time, enter `rs`
[nodemon] watching: *.*
[nodemon] starting `node -r 'dotenv/config' -r 'babel-register' src/index.js`
module.js:327
    throw err;
    ^

Error: Cannot find module ''dotenv/config''
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at module.js:498:12
    at Array.forEach (native)
    at Function.Module._preloadModules (module.js:497:12)
    at Function.startup.preloadModules (node.js:861:38)
    at startup (node.js:117:17)
    at node.js:974:3
[nodemon] app crashed - waiting for file changes before starting...
```
my npm version is 3.10.6, removing the apostrophes fixed it.