### PR TITLE
Babel-plugin-transform-class-properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "babel-eslint": "^8.0.3",
     "babel-jest": "^21.2.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-register": "^6.26.0",
     "dotenv": "^4.0.0",
     "eslint": "^4.12.1",
@@ -66,7 +67,8 @@
       ]
     ],
     "plugins": [
-      "transform-object-rest-spread"
+      "transform-object-rest-spread",
+      "transform-class-properties"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
Allows use of arrow functions within classes. Added package "babel-plugin-transform-class-properties" and adjusted package.json accordingly.
  