### PR TITLE
Move babel-plugin-transform-class-properties to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can also generate coverage with:
 yarn test --coverage
 
 # npm
-npm test --coverage
+npm test -- --coverage
 ```
 
 ### Linting

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   ],
   "dependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "body-parser": "^1.18.2",
@@ -44,7 +45,6 @@
   "devDependencies": {
     "babel-eslint": "^8.0.3",
     "babel-jest": "^21.2.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-register": "^6.26.0",
     "dotenv": "^4.0.0",
     "eslint": "^4.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,6 +537,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -556,6 +560,15 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
Two small fixes:

- Move babel-plugin-transform-class-properties to dependencies
- Update README.md: pass argument to test script with the special option `--`